### PR TITLE
[fix/#7] L002 단일 로그 정보 조회 return 값 logUuid -> userUuid 변경

### DIFF
--- a/src/main/java/crepe/backend/domain/log/service/LogService.java
+++ b/src/main/java/crepe/backend/domain/log/service/LogService.java
@@ -72,7 +72,7 @@ public class LogService {
         List<Feedback> feedbacks = feedbackRepository.findAllByLogAndIsActiveTrueOrderByCreatedAtDesc(log);
 
         return LogInfo.builder()
-                .userUuid(log.getUuid())
+                .userUuid(log.getUser().getUuid())
                 .logMessage(log.getMessage())
                 .logCreatedAt(log.getCreatedAt())
                 .resourceInfos(getResourceInfoList(resources))


### PR DESCRIPTION
1. L002 단일 로그 정보 조회 api return 값 중 "userUuid" 항목 제대로 userUuid가 나오는지 확인